### PR TITLE
Route limiting when filtering IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 Cargo.lock
+
+# Jetbrains ItelliJ IDEA
+.idea/
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/jhen0409/actix-ip-filter"
 repository = "https://github.com/jhen0409/actix-ip-filter.git"
 documentation = "https://docs.rs/actix-ip-filter/"
 version = "0.1.3"
-authors = ["jhen <developer@jhen.me>"]
+authors = ["jhen <developer@jhen.me>", "PauMAVA <paumachetti@gmail.com>"]
 edition = "2018"
 exclude = [".github/*"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,46 @@
 //!         .bind("0.0.0.0:8080")?;
 //!     Ok(())
 //! }
+//!
+//! ```
+//! ## Limiting to certain paths
+//! You can limit the allow/block actions to a certain set of patterns representing URL paths.
+//! The following code will only allow/block to paths matching the patterns `/my/path*` and
+//! `/my/other/*.csv`.
+//! ```rust
+//! use actix_web::{App, HttpServer, HttpRequest, web, middleware};
+//! use actix_ip_filter::IPFilter;
+//!
+//! async fn i_am_protected() -> &'static str {
+//!     "I am a protected resource"
+//! }
+//!
+//! async fn i_am_unprotected() -> &'static str {
+//!     "I am NOT a protected resource"
+//! }
+//!
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!
+//!
+//!     HttpServer::new(|| App::new()
+//!         // enable logger
+//!         .wrap(middleware::Logger::default())
+//!         // setup ip filters
+//!         .wrap(
+//!             IPFilter::new()
+//!                 .allow(vec!["172.??.6*.12"])
+//!                 .block(vec!["192.168.1.222"])
+//!                 .limit_to(vec!["/my/path/*"])
+//!         )
+//!         // register simple protected route
+//!         .service(web::resource("/my/path/resource").to(i_am_protected))
+//!         // register simple unprotected route
+//!         .service(web::resource("/other/path/resource").to(i_am_unprotected))
+//!     )
+//!         .bind("0.0.0.0:8000");
+//!     Ok(())
+//! }
 //! ```
 //!
 
@@ -52,6 +92,7 @@ pub struct IPFilter {
     use_x_real_ip: bool,
     allowlist: Rc<Vec<Pattern>>,
     blocklist: Rc<Vec<Pattern>>,
+    limitlist: Rc<Vec<Pattern>>,
 }
 
 
@@ -61,12 +102,23 @@ impl IPFilter {
         Default::default()
     }
 
-    /// Construct `IPFilter` middleware with the provided arguments
+    /// Construct `IPFilter` middleware with the provided arguments and no limiting pattern.
     pub fn new_with_opts(allowlist: Vec<&str>, blocklist: Vec<&str>, use_x_real_ip: bool) -> Self {
         IPFilter {
             use_x_real_ip,
             allowlist: wrap_pattern(allowlist),
             blocklist: wrap_pattern(blocklist),
+            limitlist: wrap_pattern(vec![]),
+        }
+    }
+
+    /// Construct `IPFilter` middleware with the provided arguments and limiting patterns.
+    pub fn new_with_opts_limited(allowlist: Vec<&str>, blocklist: Vec<&str>, limitlist: Vec<&str>) -> Self {
+        IPFilter {
+            use_x_real_ip,
+            allowlist: wrap_pattern(allowlist),
+            blocklist: wrap_pattern(blocklist),
+            limitlist: wrap_pattern(limitlist),
         }
     }
 
@@ -103,6 +155,20 @@ impl IPFilter {
         self.blocklist = wrap_pattern(blocklist);
         self
     }
+
+    /// Set endpoint limit list, supporting glob pattern.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use actix_ip_filter::IPFilter;
+    /// let middleware = IPFilter::new()
+    ///     .limit_to(vec!["/path/to/protected/resource*", "/protected/file/type/*.csv"]);
+    /// ```
+    pub fn limit_to(mut self, limitlist: Vec<&str>) -> Self {
+        self.limitlist = wrap_pattern(limitlist);
+        self
+    }
 }
 
 impl<S, B> Transform<S> for IPFilter
@@ -114,8 +180,8 @@ where
     type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type InitError = ();
     type Transform = IPFilterMiddleware<S>;
+    type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
@@ -124,6 +190,7 @@ where
             use_x_real_ip: self.use_x_real_ip,
             allowlist: Rc::clone(&self.allowlist),
             blocklist: Rc::clone(&self.blocklist),
+            limitlist: Rc::clone(&self.limitlist)
         })
     }
 }
@@ -133,6 +200,7 @@ pub struct IPFilterMiddleware<S> {
     use_x_real_ip: bool,
     allowlist: Rc<Vec<Pattern>>,
     blocklist: Rc<Vec<Pattern>>,
+    limitlist: Rc<Vec<Pattern>>,
 }
 
 impl<S, B> Service for IPFilterMiddleware<S>
@@ -161,8 +229,9 @@ where
             peer_addr_ip
         };
 
-        if (!self.allowlist.is_empty() && !self.allowlist.iter().any(|re| re.matches(&ip)))
-            || self.blocklist.iter().any(|re| re.matches(&ip))
+        if self.limitlist.is_empty() || self.limitlist.iter().any(|re| re.matches(req.path()))
+            && ((!self.allowlist.is_empty() && !self.allowlist.iter().any(|re| re.matches(&ip)))
+            || self.blocklist.iter().any(|re| re.matches(&ip)))
         {
             return Box::pin(ok(req.error_response(ErrorForbidden("Forbidden"))));
         }
@@ -223,5 +292,22 @@ mod tests {
             .to_srv_request();
         let resp = test::call_service(&mut fltr, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn test_limit_list() {
+        let ip_filter = IPFilter::new().block(vec!["192.168.*.11?"])
+            .limit_to(vec!["/protected/path/*"]);
+        let mut fltr = ip_filter.new_transform(test::ok_service()).await.unwrap();
+        let protected_req = test::TestRequest::with_uri("/protected/path/hello")
+            .peer_addr("192.168.0.111:8888".parse().unwrap())
+            .to_srv_request();
+        let unprotected_req = test::TestRequest::with_uri("/another/path")
+            .peer_addr("192.168.0.111:8888".parse().unwrap())
+            .to_srv_request();
+        let protected_resp = test::call_service(&mut fltr, req).await;
+        let unprotected_resp = test::call_service(&mut fltr, req).await;
+        assert_eq!(protected_resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(unprotected_resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
As discussed in #2 I have implemented a way to limit the IP filter to a set of route patterns.

Now the user can call `limit_to` to limit the filter to a vector of patterns:
```rust
use actix_web::{App, HttpServer, HttpRequest, web, middleware};
use actix_ip_filter::IPFilter;

async fn i_am_protected() -> &'static str {
    "I am a protected resource"
}

async fn i_am_unprotected() -> &'static str {
    "I am NOT a protected resource"
}

#[actix_web::main]
async fn main() -> std::io::Result<()> {
    HttpServer::new(|| App::new()
         // enable logger
        .wrap(middleware::Logger::default())
        // setup ip filters
        .wrap(
            IPFilter::new()
                .allow(vec!["172.??.6*.12"])
                .block(vec!["192.168.1.222"])
                .limit_to(vec!["/my/path/*"])
        )
        // register simple protected route
        .service(web::resource("/my/path/resource").to(i_am_protected))
        // register simple unprotected route
        .service(web::resource("/other/path/resource").to(i_am_unprotected))
    )
        .bind("0.0.0.0:8000");
    Ok(())
}
```
I have also implemented tests for this new feature:
```
$ cargo test
   Compiling actix-ip-filter v0.1.3 (/mnt/c/Users/Pau/Desktop/Programming/actix-ip-filter)
    Finished test [unoptimized + debuginfo] target(s) in 45.17s
     Running target/debug/deps/actix_ip_filter-c4104aca8a84a048

running 4 tests
test tests::test_blocklist ... ok
test tests::test_allowlist ... ok
test tests::test_limitlist ... ok
test tests::test_xrealip ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests actix_ip_filter

running 5 tests
test src/lib.rs - IPFilter::block (line 149) ... ok
test src/lib.rs - IPFilter::limit_to (line 163) ... ok
test src/lib.rs - IPFilter::allow (line 135) ... ok
test src/lib.rs - (line 38) ... ok
test src/lib.rs - (line 7) ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
Finally, I have also documented the new functions.