### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary
- Update actions/checkout from v2 to v4
- Update actions/cache from v2 to v4

This PR updates the GitHub Actions workflow to use the latest versions of the checkout and cache actions, which include performance improvements and better security.

This PR contains ONLY the CI updates, with no other changes.

🤖 Generated with [Claude Code](https://claude.ai/code)